### PR TITLE
Disable euler font in formulas

### DIFF
--- a/documentation/kernel-semantics.tex
+++ b/documentation/kernel-semantics.tex
@@ -4,8 +4,6 @@
 %
 \usepackage{a4wide}
 %
-\usepackage{euler}
-%
 \usepackage{url,cite,amssymb,stmaryrd,alltt,xypic,appendix}
 %
 \usepackage{color,alltt}


### PR DESCRIPTION
This is a questionable change, so I'm uploading it as a pull request.  To me euler font makes it difficult to distinguish between italics and normal text.  What's your opinion on this, Zhivka?