### PR TITLE
Redefine \emptyset to \varnothing

### DIFF
--- a/documentation/kernel-semantics.tex
+++ b/documentation/kernel-semantics.tex
@@ -31,6 +31,7 @@
 % Macros used below have been contributed in part by Olivier Danvy and Kevin Millikin
 \input{danvy-millikin-LMCS.mac}
 
+\renewcommand{\emptyset}{\varnothing}
 \DeclareMathOperator{\extend}{extend}
 
 \begin{document}


### PR DESCRIPTION
Another questionable change: redefine \emptyset so that it works like \varnothing.  The latter looks more round and is harder to confuse with zero in some monotype fonts.  The symbols may be seen together for comparison, for example, here: https://en.wikipedia.org/wiki/Empty_set#Notation.