### PR TITLE
Remove the prime symbol from a variable name

### DIFF
--- a/documentation/kernel-semantics.tex
+++ b/documentation/kernel-semantics.tex
@@ -1184,8 +1184,8 @@ The value corresponding to the evaluated expression is captured by the applicati
     &\begin{multlined}
         \cesktranswheresplit%
             {\evallistconf{\expr :: \exprs}{\env}{\strace}{\cstrace}{\cex}{\acont}}%
-            {\evalconf{\expr}{\env}{\strace}{\cstrace}{\cex}{\econt'}}%
-            {\text{where $\econt' = \ExpressionsK{\exprs}{\env}{\acont}$}}
+            {\evalconf{\expr}{\env}{\strace}{\cstrace}{\cex}{\econt}}%
+            {\text{where $\econt = \ExpressionsK{\exprs}{\env}{\acont}$}}
     \end{multlined}\\
     &\cesktrans%
         {\evallistconf{[]}{\env}{\strace}{\cstrace}{\cex}{\acont}}%


### PR DESCRIPTION
In the affected equation, it doesn't matter if we use \kappa or \kappa'.