### PR TITLE
Add definition for S in SuperMethod invocation and align where

### DIFF
--- a/documentation/kernel-semantics.tex
+++ b/documentation/kernel-semantics.tex
@@ -1068,7 +1068,7 @@ Application continuations, $\acont$, capture the application of a list of values
 \newcommand{\RedirectingA}[3]{\mathrm{RedirectingA}({#1},\,{#2},\,\strace,\,\handler,\,\cstrace,\,\cex,\,{#3})}
 \newcommand{\ForInitA}[1]{\mathrm{ForInitA}(\mathrm{\varmeta{s}},\, #1,\, \exprs,\, \statementmeta,\, \env,\, \lbls,\, \clbls,\, \handler,\, \cstrace,\, \cex,\, \econt,\, \scont)}
 \newcommand{\ForUpdatesA}[2]{\mathrm{ForUpdatesA}(\mathrm{\varmeta{s}},\, #1,\, \exprs,\, \statementmeta,\, \env,\, #2,\, \lbls,\, \clbls,\, \handler,\, \cstrace,\, \cex,\, \econt,\, \scont)}
-\newcommand{\InstanceMethodA}{\mathrm{InstanceMethodA(\idmeta,\,\val,\,\strace,\,\handler,\,\cstrace,\,\cex,\,\econt)}}
+\newcommand{\InstanceMethodA}{\mathrm{InstanceMethodA}(\idmeta,\,\val,\,\strace,\,\handler,\,\cstrace,\,\cex,\,\econt)}
 
 We use the application continuation $\ValueA{\acont}{\val}$, capturing a value and an application continuation, as application that adds a value to the list of values to eventually used by an application continuation that produces a configuration other than ApplicationConfiguration.
 We suffix the names of application continuations with ``$A$''.
@@ -2167,6 +2167,7 @@ After the evaluation of the argument expression to a value $\val$, depending on 
     \end{eqfigure}
 \end{figure}
 
+
 \begin{figure}[Htp]
     \begin{eqfigure}
     \begin{align}
@@ -2174,26 +2175,34 @@ After the evaluation of the argument expression to a value $\val$, depending on 
             \cesktranswheresplit*%
             {\contconf{\InstanceMethodA}{\val{s}}}%
             {\execconf{\stmt}{\env}{[]}{[]}{\strace}{\handler}{\cex,\,\cstrace}{\econt}{\scont}}%
-            {\parbox{10cm}{where $\membermeta = class(\val).lookup(\idmeta)$ is an instance method with body $\stmt$ and formals $\formals$\\
-            $\scont = \ExitSK{\nnull}$\\
-            $\env = \ext{\env_{empty}}{\this :: \formals}{\val :: \val{s}}$}}
+            {\begin{aligned}
+                \text{where } \membermeta &= class(\val).lookup(\idmeta)\text{ is an instance method with body $\stmt$ and formals $\formals$},\\
+                              \scont &= \ExitSK{\nnull},\\
+                              \env &= \ext{\env_{empty}}{\this :: \formals}{\val :: \val{s}}
+            \end{aligned}}
     \end{multlined}
     \label{acontconf:instancemethod}\\
     &\begin{multlined}
             \cesktranswheresplit*%
             {\contconf{\DInstanceMethodA}{\val{s}}}%
             {\execconf{\stmt}{\env}{[]}{[]}{\strace}{\handler}{\cex,\,\cstrace}{\econt}{\scont}}%
-            {\parbox{10cm}{where $\stmt$ is the statement body and $\formals$ are the formal parameters of the instace method $\membermeta$\\
-            $\scont = \ExitSK{\nnull}$,\\
-            $\env = \ext{\env_{empty}}{\this :: \formals}{\val :: \val{s}}$}}
+            {\begin{aligned}
+                \text{where } \stmt &\text{ is the statement body and $\formals$ are the formal parameters of the instace method $\membermeta$},\\
+                              \scont &= \ExitSK{\nnull},\\
+                              \env &= \ext{\env_{empty}}{\this :: \formals}{\val :: \val{s}}
+            \end{aligned}}
     \end{multlined}
     \label{acontconf:dinstancemethod}\\
     &\begin{multlined}
         \cesktranswheresplit*%
         {\contconf{\SuperMethodA{\strace}}{\val{s}}}%
         {\execconf{\stmt}{\env'}{[]}{[]}{\strace}{\handler}{\cex,\,\cstrace}{\econt}{\scont}}%
-        {\parbox{10cm}{where $\scont = \ExitSK{\nnull}$,\\
-        $\env' = \ext{\env_{empty}}{\this :: \formals}{\deref{(\env(\this))} :: \val{s}}$    }}
+        {\begin{aligned}
+            \text{where } \membermeta &= superclass(class(\val)).lookup(\idmeta)\text{ is an instance method with body $\stmt$ and formals $\formals$},\\
+                          \scont &= \ExitSK{\nnull},\\
+                          \env' &= \ext{\env_{empty}}{\this :: \formals}{\val :: \val{s}},\\
+                          \val &= \deref{(\env(\this))}
+        \end{aligned}}
     \end{multlined}
     \label{acontconf:superinstancemethod}
     \end{align}


### PR DESCRIPTION
- Adds a clause in the where statement for S in super method invocation.
- Aligns the where clauses in the figure
- Unifies the notation for value. Before we have a non cursive "v" in InstanceMethodA, now it is cursive.