### PR TITLE
Initial specification for Asyc

### DIFF
--- a/documentation/kernel-semantics.tex
+++ b/documentation/kernel-semantics.tex
@@ -316,24 +316,25 @@ This section contains definitions of syntactic and semantic domains, helper func
     \pi_i(x) &\text{ --- the $i^{th}$ component of $x \in \ddom_1 \times \dots \times \ddom_n$}.
 \end{align*}
 
-\subsubsection{Semantic list}
-\label{subsubsec:semantic-list}
+\subsubsection{Meta list}
+\label{subsubsec:meta-list}
 
-Throughout the document we use semantic lists which represent lists of elements from some semantic domain.
+Throughout the document we use meta lists which represent lists of elements from some domain.
 We define a list $l \in \mlist{\ddom}$ and are constructed as follows:
 \begin{align*}
     [] &\text{ --- empty list}.\\
     x :: \textit{list} &\text{ --- a meta-list that is constructed by adding element $x \in \ddom$ to the head of the meta-list $list$}.
 \end{align*}
 
+\todo{Define behaviour for operations on empty list.}
 In addition of the usual $\head$ and $\tail$ operations on a list, we add $\append$ operator.
 \begin{align*}
     &\head \in \mlist{\ddom} \rightarrow \ddom\\
-    &\head(x :: \textit{list}) = x \text{ where $x :: \text{list} \in \mlist{\ddom}$ is a non empt y list}\\[2mm]
+    &\head(x :: \textit{list}) = x \text{ where $x :: \text{list} \in \mlist{\ddom}$}\\
     &\tail \in \mlist{\ddom} \rightarrow \mlist{\ddom}\\
-    &\tail(x :: \textit{list}) = list \text{ where $x :: \text{list} \in \mlist{\ddom}$ is a non empt y list}\\[2mm]
+    &\tail(x :: \textit{list}) = list \text{ where $x :: \text{list} \in \mlist{\ddom}$}\\
     &\append \in \mlist{\ddom} \times \ddom \rightarrow \mlist{\ddom}\\
-    &\append(list, x) = list ::: x \text{ where $x \in \ddom$ is added as last element of the $list \in \mlist{\ddom}$}
+    &\append(\textit{list}, x) = \textit{list'} \text{ where $x \in \ddom$ is the last element of $\textit{list}' \in \mlist{\ddom}$}\\
 \end{align*}
 
 
@@ -3175,26 +3176,23 @@ Let $F$ be a function with a body $\stmt_{body}$ and a list of formal parameters
 \subsection{Event Loop}
 \label{subsec:eventloop}
 
-\dart{} supports asynchronous execution of code with async functions and await expressions.
-We introduce an event loop to define the behaviour of asynchronous code.
+\dart{} supports asynchronous execution of code with async functions, await expressions, and asynchronous for-in loops.
+We introduce an event loop component to represent Dart's event loop.
 We denote the event loop with $\eventloop$.
-$\eventloop$ represents a list of event continuations, elements of $\dncont$.
+$\eventloop$ is a list of event continuations, elements of $\dncont$.
 \[
     \eventloop \in \mlist{\dncont}
 \]
 
 The event loop is a list and it supports the operations defined in Section~\ref{subsubsec:semantic-list}.
 
-The event loop appears on the left and the right-hand side of all configurations, therefore we omit it from rules where the same queue just passed from one state to the other.
-We assume it is implicit and we explicitly mention the cases when the event loop on the right-hand side is not the same as the one passed in the next state.
-
 \subsubsection{Async}
 \label{subsubsec:async}
 
-Asynchronous execution in \dart{} is supported with async functions or asynchronous for in loops.
-In \kernel{} await is an expression and here we present the behaviour of invocation of asynchronous functions.
-Asynchronous for-in loops occur as statements.
-The semantics of the await expression in \kernel{} for expressions other then the above mentioned does not modify the event loop.
+Asynchronous execution in \dart{} is supported with async functions, await expressions, and asynchronous for-in loops.
+In \kernel{} $\AwaitExpression{}$ is an expression and here we present the behaviour of invocation of asynchronous functions.
+Asynchronous \synt{for in} loops occur as statements.
+The semantics of the $\AwaitExpression{}$ expression in \kernel{} for expressions other then the above mentioned does not modify the event loop.
 
 Otherwise, the await expression modifies the event loop and proceeds to a state that that applies an event continuation from the event loop, i.e., an event loop configuration.
 Invocation of asynchronous functions without an await modifies the event loop, but continues with the next continuation.
@@ -3214,6 +3212,7 @@ What to read:
 
 Along other things, the following is not considered in the basic version:
 \begin{itemize}
+	\item Event loop component needs to be added to all configurations.
     \item Exception handlers should be updated with a handler that completes the future.
 
     \item Semantics for invocations of async functions other then static invocations should be added.
@@ -3222,17 +3221,20 @@ Along other things, the following is not considered in the basic version:
 
 \end{itemize}
 
+% Move these macros next to the rest of the macros.
 \renewcommand{\StartNK}[4]{\mathrm{StartNK}({#1},\,{#2},\,{#3},\,\ExceptionHandlersRest,\,{#4})}
 \newcommand{\CompleteFutureEK}[1]{\mathrm{CompleteFutureEK}({#1})}
 \newcommand{\AwaitReturnNK}[2]{\mathrm{AwaitReturnNK}({#1},\,{#2})}
 \newcommand{\AwaitEK}{\mathrm{AwaitEK}(\econt)}
 \newcommand{\AsyncStaticInvA}[4]{\mathrm{AsyncStaticInvA}({#1},\,{#2},\,{#3},\,\ExceptionHandlersRest,\,{#4})}
+\newcommand{\FutureValue}[1]{\mathrm{FutureValue}(#1)}
+\newcommand{\dfuture}{\mathbf{FutureValue}}
 
-If await continuation, $\AwaitEK$ is applied to a FutureValue, it needs to "complete" the future before returning, 
+When an await continuation, $\AwaitEK$, is applied to a $\FutureValue{\loc}$, it needs to "complete" the future before returning.
 Therefore, it adds an event continuation at the tail of the loop that captures the return continuation and the location from the store corresponding to the returned future.
-It then applies the head event continuation of the event loop.
+It then proceeds to the head event continuation of the event loop.
 
-When the body of async function is about to be executed, we create a $\StartNK{\stmt}{\env}{\strace}{\econt'}$ event continuation that captures the body, the environment, the exception components and an expression continuation that completes the corresponding future.
+When the body of async function is about to be executed, we create a $\StartNK{\stmt}{\env}{\strace}{\econt'}$ event continuation that captures the body, the environment, the exception components and an expression continuation that completes the corresponding $\FutureValue{\loc}$.
 We append this event continuation to the event loop and the invocation evaluates to a future immediately.
 The created future value captures the location where the completed value of the future will eventually be stored.
 The future is completed eventually, when the above mentioned continuation from the event loop is applied.
@@ -3279,11 +3281,11 @@ Transition to this state will happen when a failure to handle an exception occur
         &\begin{multlined}
              \cesktranswheresplit%
                  {\contconf{\AwaitEK}{\val}}%
-                 {\eventconf{\head(\eventloop)}{\eventloop'}}%
+                 {\eventconf{\head(\eventloop')}{\tail(\eventloop')}}%
                  {\begin{aligned}
                      \text{where }
-                     \val &\in \textbf{FutureValue}\\
-                     \eventloop' &= \tail(\append(\eventloop, \AwaitReturnNK{\econt}{\loc})
+                     \val &= \FutureValue{\loc}\\
+                     \eventloop' &= \append(\eventloop, \AwaitReturnNK{\econt}{\loc})
                  \end{aligned}}
         \end{multlined}\label{async:econt-future}\\
         &\begin{multlined}

--- a/documentation/kernel-semantics.tex
+++ b/documentation/kernel-semantics.tex
@@ -56,6 +56,11 @@
 \DeclareMathOperator{\lookup}{lookup}
 \DeclareMathOperator{\methodLookup}{methodLookup}
 
+% Meta-functions for operations on list
+\DeclareMathOperator{\head}{head}
+\DeclareMathOperator{\tail}{tail}
+\DeclareMathOperator{\append}{append}
+
 % Keywords and syntactic constructs of Dart Kernel to be used in math mode.
 \newcommand{\synt}[1]{\ensuremath{\text{\textbf{\texttt{#1}}}}}
 \DeclareMathOperator{\dowhile}{\synt{do~while}}
@@ -307,10 +312,28 @@ This section contains definitions of syntactic and semantic domains, helper func
 \label{subsec:notations}
 
 \begin{align*}
-    [] &\text{ --- empty list}.\\
-    \varmeta :: list &\text{ --- a meta-list that is constructed by adding element $\varmeta$ to the head of the meta-list $list$}.\\
     \dom(f) &\text{ --- the domain of function \(f\)}.\\
     \pi_i(x) &\text{ --- the $i^{th}$ component of $x \in \ddom_1 \times \dots \times \ddom_n$}.
+\end{align*}
+
+\subsubsection{Semantic list}
+\label{subsubsec:semantic-list}
+
+Throughout the document we use semantic lists which represent lists of elements from some semantic domain.
+We define a list $l \in \mlist{\ddom}$ and are constructed as follows:
+\begin{align*}
+    [] &\text{ --- empty list}.\\
+    x :: \textit{list} &\text{ --- a meta-list that is constructed by adding element $x \in \ddom$ to the head of the meta-list $list$}.
+\end{align*}
+
+In addition of the usual $\head$ and $\tail$ operations on a list, we add $\append$ operator.
+\begin{align*}
+    &\head \in \mlist{\ddom} \rightarrow \ddom\\
+    &\head(x :: \textit{list}) = x \text{ where $x :: \text{list} \in \mlist{\ddom}$ is a non empt y list}\\[2mm]
+    &\tail \in \mlist{\ddom} \rightarrow \mlist{\ddom}\\
+    &\tail(x :: \textit{list}) = list \text{ where $x :: \text{list} \in \mlist{\ddom}$ is a non empt y list}\\[2mm]
+    &\append \in \mlist{\ddom} \times \ddom \rightarrow \mlist{\ddom}\\
+    &\append(list, x) = list ::: x \text{ where $x \in \ddom$ is added as last element of the $list \in \mlist{\ddom}$}
 \end{align*}
 
 
@@ -1695,7 +1718,7 @@ The specific CESK-transitions for the different invocations are described in the
         \end{multlined}
         \label{eval:staticinvoc}
     \end{align}
-    \caption{The CESK-transition function for EvalConfiguration: static variable extraction and assignment, and static method invocation}
+    \caption{The CESK-transition function for EvalConfiguration: static variable extraction and assignment, and sync static method invocation}
     \label{table:static-evalconfigs}
     \end{eqfigure}
 \end{figure}
@@ -3152,12 +3175,29 @@ Let $F$ be a function with a body $\stmt_{body}$ and a list of formal parameters
 \subsection{Event Loop}
 \label{subsec:eventloop}
 
+\dart{} supports asynchronous execution of code with async functions and await expressions.
+We introduce an event loop to define the behaviour of asynchronous code.
+We denote the event loop with $\eventloop$.
+$\eventloop$ represents a list of event continuations, elements of $\dncont$.
+\[
+    \eventloop \in \mlist{\dncont}
+\]
+
+The event loop is a list and it supports the operations defined in Section~\ref{subsubsec:semantic-list}.
+
+The event loop appears on the left and the right-hand side of all configurations, therefore we omit it from rules where the same queue just passed from one state to the other.
+We assume it is implicit and we explicitly mention the cases when the event loop on the right-hand side is not the same as the one passed in the next state.
 
 \subsubsection{Async}
 \label{subsubsec:async}
 
+Asynchronous execution in \dart{} is supported with async functions or asynchronous for in loops.
+In \kernel{} await is an expression and here we present the behaviour of invocation of asynchronous functions.
+Asynchronous for-in loops occur as statements.
+The semantics of the await expression in \kernel{} for expressions other then the above mentioned does not modify the event loop.
+Otherwise, the await expression modifies the event loop and proceeds to a state that that applies an event continuation from the event loop, i.e., an event loop configuration.
 
-
+Invocation of asynchronous functions without an await modifies the event loop, but continues with the next continuation.
 
 Notes here are for those who will rewrite the basic async specification into full async specification.
 They should be changed in the final version.
@@ -3174,14 +3214,104 @@ What to read:
 
 Along other things, the following is not considered in the basic version:
 \begin{itemize}
-    \item The labels and switch labels are omitted.
+    \item Exception handlers should be updated with a handler that completes the future.
 
-    \item The exception-related components and transitions are omitted.
+    \item Semantics for invocations of async functions other then static invocations should be added.
 
-    \item For simplicity, all functions are considered to have exactly one required positional parameter and zero named parameters.
+    \item Elements from $\textbf{FutureValue}$ should be specified.
 
 \end{itemize}
 
+If await continuation is applied to a FutureValue, it need to "complete" the future, hence it starts the event loop.
+
+When body of async is about to be executed we add to the event loop the event cont and eval the invocation to a future immediately.
+
+
+\renewcommand{\StartNK}[4]{\mathrm{StartNK}({#1},\,{#2},\,{#3},\,\ExceptionHandlersRest,\,{#4})}
+\newcommand{\CompleteFutureEK}[1]{\mathrm{CompleteFutureEK}({#1})}
+\newcommand{\AwaitReturnNK}[2]{\mathrm{AwaitReturnNK}({#1},\,{#2})}
+\newcommand{\AwaitEK}{\mathrm{AwaitEK}(\econt)}
+\newcommand{\AsyncStaticInvA}[4]{\mathrm{AsyncStaticInvA}({#1},\,{#2},\,{#3},\,\ExceptionHandlersRest,\,{#4})}
+
+\begin{figure}[Htp]
+    \begin{eqfigure}
+    \begin{align}
+        &\begin{multlined}
+            \cesktranswheresplit%
+                {\evalconf{\AwaitExpression{\expressionmeta}}{\env}{st}{cex}{cst}{\econt}}%
+                {\evalconf{\expressionmeta}{\env}{st}{cex}{cst}{\econt'}}%
+                {\text{where } \econt' = \AwaitEK}
+        \end{multlined}\label{async:await}\\
+        &\begin{multlined}
+            \cesktranswheresplit%
+                {\evalconf{\StaticInvocation{\{\membermeta\}}{\expressionsmeta}}{\env}{\strace}{\cstrace}{\cex}{\econt}}%
+                {\evallistconf{\exprs}{\env}{\strace}{\cstrace}{\cex}{\acont}}%
+                {\begin{aligned}
+                    \text{where }
+                    \acont &= \AsyncStaticInvA{\formals}{\stmt}{\strace'}{\econt},\\
+                    \strace' &= \StaticInvocation{\{\membermeta\}}{\expressionsmeta}::\strace,\\
+                    \membermeta &\text{ is an async static method with formal parameters }\formals \text{ and body }\stmt
+                  \end{aligned}}
+        \end{multlined}\label{async:static-invoc}\\
+        &\begin{multlined}
+             \cesktranswheresplit%
+                 {\acontconf{\AsyncStaticInvA{\formals}{\stmt}{\strace}{\econt}}{\val{s}}}%
+                 {\contconf{\econt}{\val}}%
+                 {\begin{aligned}
+                     \text{where }
+                     \val &= FutureValue(\loc)\\
+                     \loc &= \text{fresh location in the store}\\
+                     \eventloop_{R} &= \append(\eventloop_{L},\ncont)\\
+                     \ncont &= \StartNK{\stmt}{\env}{\strace}{\econt'}\\
+                     \econt' &= \CompleteFutureEK{\loc}\\
+                     \env &= \ext{\env_{empty}}{\formals}{\val{s}}
+                  \end{aligned}}
+        \end{multlined}\label{async:static-invoc-a}\\
+        &\begin{multlined}
+             \cesktranswheresplit%
+                 {\contconf{\AwaitEK}{\val}}%
+                 {\eventconf{\head(\eventloop)}{\eventloop'}}%
+                 {\begin{aligned}
+                     \text{where }
+                     \val &\in \textbf{FutureValue}\\
+                     \eventloop' &= \tail(\append(\eventloop, \AwaitReturnNK{\econt}{\loc})
+                 \end{aligned}}
+        \end{multlined}\label{async:econt-future}\\
+        &\begin{multlined}
+             \cesktranswhere%
+                 {\contconf{\AwaitEK}{\val}}%
+                 {\contconf{\econt}{\val}}%
+                 {\text{where }\val \notin \textbf{FutureValue}}
+        \end{multlined}\label{async:econt-value}\\
+        &\begin{multlined}
+             \cesktranswheresplit%
+                 {\eventconf{\StartNK{\stmt}{\env}{\strace}{\econt}}{\eventloop}}%
+                 {\execconf{\stmt}{\env}{[]}{[]}{\strace}{\handler}{\cex,\,\cstrace}{\econt}{\scont}}%
+                 {\text{where } \scont = \ExitSK{null}}
+        \end{multlined}\label{async:startnk}\\
+         &\begin{multlined}
+             \cesktranswheresplit%
+                 {\contconf{\CompleteFutureEK{\loc}}{\val}}%
+                 {\eventconf{\head(G)}{\tail(G)}}%
+                 {\text{where } \deref{\loc} = \val \text{ after transition}}
+        \end{multlined}\label{async:complete-future}\\
+        &\begin{multlined}
+             \cesktranswhere%
+                 {\contconf{\AwaitReturnNK{\econt}{\loc}}{\eventloop}}%
+                 {\contconf{\econt}{\deref{\loc}}}%
+                 {\text{where } \deref{\loc} \neq \emptyset}
+        \end{multlined}\label{async:await-return}\\
+        &\begin{multlined}
+             \cesktranswheresplit%
+                 {\contconf{\AwaitReturnNK{\econt}{\loc}}{\eventloop}}%
+                 {\eventconf{\head(\eventloop')}{\tail(\eventloop')}}%
+                 {\text{where } \deref{\loc} = \emptyset,\,\eventloop' = \append(\eventloop,\, \AwaitReturnNK{\econt}{\loc})}
+        \end{multlined}\label{async:await-return-fail}\\
+  \end{align}
+  \end{eqfigure}
+  \caption{The CESK-transition function for await expressions}
+  \label{fig:async}
+\end{figure}
 
 \subsubsection{Sync*}
 \label{subsubsec:syncstar}

--- a/documentation/kernel-semantics.tex
+++ b/documentation/kernel-semantics.tex
@@ -3224,8 +3224,12 @@ Along other things, the following is not considered in the basic version:
 
 If await continuation is applied to a FutureValue, it need to "complete" the future, hence it starts the event loop.
 
-When body of async is about to be executed we add to the event loop the event cont and eval the invocation to a future immediately.
-
+When body of async is about to be executed we add to the event loop the event continuation.
+The invocation evaluates to a future immediately.
+The future is completed eventually, when continuation from the event loop are applied.
+Additionally, we need to mention that the execution of the program completes when a final state is reached and the event loop is empty.
+Note that this implies the introduction of an exit state, which will not proceed to application of continuations from the event loop.
+Transition to this state will happen when a failure to handle an exception occurs.
 
 \renewcommand{\StartNK}[4]{\mathrm{StartNK}({#1},\,{#2},\,{#3},\,\ExceptionHandlersRest,\,{#4})}
 \newcommand{\CompleteFutureEK}[1]{\mathrm{CompleteFutureEK}({#1})}

--- a/documentation/kernel-semantics.tex
+++ b/documentation/kernel-semantics.tex
@@ -3195,8 +3195,8 @@ Asynchronous execution in \dart{} is supported with async functions or asynchron
 In \kernel{} await is an expression and here we present the behaviour of invocation of asynchronous functions.
 Asynchronous for-in loops occur as statements.
 The semantics of the await expression in \kernel{} for expressions other then the above mentioned does not modify the event loop.
-Otherwise, the await expression modifies the event loop and proceeds to a state that that applies an event continuation from the event loop, i.e., an event loop configuration.
 
+Otherwise, the await expression modifies the event loop and proceeds to a state that that applies an event continuation from the event loop, i.e., an event loop configuration.
 Invocation of asynchronous functions without an await modifies the event loop, but continues with the next continuation.
 
 Notes here are for those who will rewrite the basic async specification into full async specification.
@@ -3222,20 +3222,25 @@ Along other things, the following is not considered in the basic version:
 
 \end{itemize}
 
-If await continuation is applied to a FutureValue, it need to "complete" the future, hence it starts the event loop.
-
-When body of async is about to be executed we add to the event loop the event continuation.
-The invocation evaluates to a future immediately.
-The future is completed eventually, when continuation from the event loop are applied.
-Additionally, we need to mention that the execution of the program completes when a final state is reached and the event loop is empty.
-Note that this implies the introduction of an exit state, which will not proceed to application of continuations from the event loop.
-Transition to this state will happen when a failure to handle an exception occurs.
-
 \renewcommand{\StartNK}[4]{\mathrm{StartNK}({#1},\,{#2},\,{#3},\,\ExceptionHandlersRest,\,{#4})}
 \newcommand{\CompleteFutureEK}[1]{\mathrm{CompleteFutureEK}({#1})}
 \newcommand{\AwaitReturnNK}[2]{\mathrm{AwaitReturnNK}({#1},\,{#2})}
 \newcommand{\AwaitEK}{\mathrm{AwaitEK}(\econt)}
 \newcommand{\AsyncStaticInvA}[4]{\mathrm{AsyncStaticInvA}({#1},\,{#2},\,{#3},\,\ExceptionHandlersRest,\,{#4})}
+
+If await continuation, $\AwaitEK$ is applied to a FutureValue, it needs to "complete" the future before returning, 
+Therefore, it adds an event continuation at the tail of the loop that captures the return continuation and the location from the store corresponding to the returned future.
+It then applies the head event continuation of the event loop.
+
+When the body of async function is about to be executed, we create a $\StartNK{\stmt}{\env}{\strace}{\econt'}$ event continuation that captures the body, the environment, the exception components and an expression continuation that completes the corresponding future.
+We append this event continuation to the event loop and the invocation evaluates to a future immediately.
+The created future value captures the location where the completed value of the future will eventually be stored.
+The future is completed eventually, when the above mentioned continuation from the event loop is applied.
+
+Additionally, we need to mention that the execution of the program completes when a final state is reached and the event loop is empty.
+Note that this implies the introduction of an exit state, which will not proceed to application of continuations from the event loop.
+Transition to this state will happen when a failure to handle an exception occurs.
+
 
 \begin{figure}[Htp]
     \begin{eqfigure}

--- a/documentation/kernel-semantics.tex
+++ b/documentation/kernel-semantics.tex
@@ -2348,7 +2348,7 @@ When a $\return$ statement is missing in the statement body $\stmt$ of the insta
 \label{subsubsec:direct-instance-method-invoc}
 
 Direct method invocation allows invocation of instance method by providing directly the member method to be invoked and bypass the lookup step described in Section~\ref{subsubsec:instance-method-invoc} above.
-The evaluation of the direct instance method invocation proceeds with the evaluation of the left-hand side expression, i.e., the receiver expression as shown in \eqref{eval:dinstancemethod}.
+The evaluation of the direct instance method invocation proceeds with the evaluation of the left-hand side expression, i.e. the receiver expression as shown in \eqref{eval:dinstancemethod}.
 After the evaluation of the receiver expression to a value $\val$, the evaluation proceeds with the evaluation of the argument expressions as shown in \eqref{acontconf:dinstancemethod}.
 The argument expressions are evaluated to a list of values $\vals$.
 The evaluation of the expression continues with the execution of the statement body in the environment that binds $\this$ to a location that stores the value $\val$ and the formal parameters $\formals$ to fresh locations storing values from $\vals$ accordingly.
@@ -2399,7 +2399,7 @@ We support the following kinds of initializers:
 \end{itemize}
 
 
-A new object value is allocated only a constructor is run with $\new$, i.e., invoked, otherwise we say that the constructor is run to further initialize an already allocated object value.
+A new object value is allocated only a constructor is run with $\new$, i.e. invoked, otherwise we say that the constructor is run to further initialize an already allocated object value.
 
 Let $\new(Q(\expressionsmeta))$ be an expression invokes a constructor $Q$ to produce a new instance.
 The invocation of a constructor $Q$ proceeds by evaluating the actual argument expressions as shown in \eqref{eval:new}.
@@ -3188,13 +3188,21 @@ The event loop is a list and it supports the operations defined in Section~\ref{
 
 \subsubsection{Async}
 \label{subsubsec:async}
+% Move these macros next to the rest of the macros.
+\renewcommand{\StartNK}[4]{\mathrm{StartNK}({#1},\,{#2},\,{#3},\,\ExceptionHandlersRest,\,{#4})}
+\newcommand{\CompleteFutureEK}[1]{\mathrm{CompleteFutureEK}({#1})}
+\newcommand{\AwaitReturnNK}[2]{\mathrm{AwaitReturnNK}({#1},\,{#2})}
+\newcommand{\AwaitEK}{\mathrm{AwaitEK}(\econt)}
+\newcommand{\AsyncStaticInvA}[4]{\mathrm{AsyncStaticInvA}({#1},\,{#2},\,{#3},\,\ExceptionHandlersRest,\,{#4})}
+\newcommand{\FutureValue}[1]{\mathrm{FutureValue}(#1)}
+\newcommand{\dfuture}{\mathbf{FutureValue}}
 
 Asynchronous execution in \dart{} is supported with async functions, await expressions, and asynchronous for-in loops.
 In \kernel{} $\AwaitExpression{}$ is an expression and here we present the behaviour of invocation of asynchronous functions.
 Asynchronous \synt{for in} loops occur as statements.
-The semantics of the $\AwaitExpression{}$ expression in \kernel{} for expressions other then the above mentioned does not modify the event loop.
+The semantics of the $\AwaitExpression{}$ expression in \kernel{} for expressions that do not evaluate to an element of $\dfuture$ does not modify the event loop.
 
-Otherwise, the await expression modifies the event loop and proceeds to a state that that applies an event continuation from the event loop, i.e., an event loop configuration.
+Otherwise, the await expression modifies the event loop and proceeds to a state that that applies an event continuation from the event loop, i.e. an event loop configuration.
 Invocation of asynchronous functions without an await modifies the event loop, but continues with the next continuation.
 
 Notes here are for those who will rewrite the basic async specification into full async specification.
@@ -3217,21 +3225,13 @@ Along other things, the following is not considered in the basic version:
 
     \item Semantics for invocations of async functions other then static invocations should be added.
 
-    \item Elements from $\textbf{FutureValue}$ should be specified.
+    \item Elements from $\dfuture$ should be specified.
 
 \end{itemize}
 
-% Move these macros next to the rest of the macros.
-\renewcommand{\StartNK}[4]{\mathrm{StartNK}({#1},\,{#2},\,{#3},\,\ExceptionHandlersRest,\,{#4})}
-\newcommand{\CompleteFutureEK}[1]{\mathrm{CompleteFutureEK}({#1})}
-\newcommand{\AwaitReturnNK}[2]{\mathrm{AwaitReturnNK}({#1},\,{#2})}
-\newcommand{\AwaitEK}{\mathrm{AwaitEK}(\econt)}
-\newcommand{\AsyncStaticInvA}[4]{\mathrm{AsyncStaticInvA}({#1},\,{#2},\,{#3},\,\ExceptionHandlersRest,\,{#4})}
-\newcommand{\FutureValue}[1]{\mathrm{FutureValue}(#1)}
-\newcommand{\dfuture}{\mathbf{FutureValue}}
 
 When an await continuation, $\AwaitEK$, is applied to a $\FutureValue{\loc}$, it needs to "complete" the future before returning.
-Therefore, it adds an event continuation at the tail of the loop that captures the return continuation and the location from the store corresponding to the returned future.
+Therefore, it adds an event continuation at the tail of the event loop that captures the return continuation and the location from the store corresponding to the returned future.
 It then proceeds to the head event continuation of the event loop.
 
 When the body of async function is about to be executed, we create a $\StartNK{\stmt}{\env}{\strace}{\econt'}$ event continuation that captures the body, the environment, the exception components and an expression continuation that completes the corresponding $\FutureValue{\loc}$.
@@ -3270,7 +3270,7 @@ Transition to this state will happen when a failure to handle an exception occur
                  {\contconf{\econt}{\val}}%
                  {\begin{aligned}
                      \text{where }
-                     \val &= FutureValue(\loc)\\
+                     \val &= \FutureValue{\loc}\\
                      \loc &= \text{fresh location in the store}\\
                      \eventloop_{R} &= \append(\eventloop_{L},\ncont)\\
                      \ncont &= \StartNK{\stmt}{\env}{\strace}{\econt'}\\
@@ -3292,7 +3292,7 @@ Transition to this state will happen when a failure to handle an exception occur
              \cesktranswhere%
                  {\contconf{\AwaitEK}{\val}}%
                  {\contconf{\econt}{\val}}%
-                 {\text{where }\val \notin \textbf{FutureValue}}
+                 {\text{where }\val \notin \dfuture}
         \end{multlined}\label{async:econt-value}\\
         &\begin{multlined}
              \cesktranswheresplit%


### PR DESCRIPTION
This PR proposes an architecture for the evaluation of invocation of async functions and await expressions with an event loop and Futures.

Note that:
- These rules do not specify the behavior of `await for( ... )`, which occurs as a statement in Kernel.
- Elements of the newly introduced domain of values, FutureValue, are not fully specified.
- Rules for invocation of async function other then static invocation, while being analogous to the former, are not specified.

Exception handlers should be updated as follows: 
- A new top level exception handler needs to be added, to handle the case when an exception is not handled by a try/catch in the event continuation.
- Future is completed in the top level exception handler with the error and the stack trace and execution of the program continues normally.

I am creating this change as a PR, since it is based on Dima's proposal for invocation of async static functions with await, but are not a direct transcription of the proposed rules, and I would like him to review it before we add it to the spec. 
